### PR TITLE
understand-twemproxy-woes

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -12,6 +12,9 @@ AllCops:
 # with minimal friction, not forced to make a hard choice between
 # cutting tests or splitting up my test suites.
 #
+Metrics/BlockLength:
+  Exclude:
+    - 'test/**/*.rb'
 Metrics/ClassLength:
   Max: 400
   Exclude:
@@ -141,7 +144,9 @@ Style/TernaryParentheses:
 # I am a huge fan of using trailing commas when I break an argument
 # list down one-per line.
 #
-# As such, I reject this test.
+# As such, I reject these tests.
 #
+Style/TrailingCommaInArguments:
+  Enabled: false
 Style/TrailingCommaInLiteral:
   Enabled: false

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,8 +3,9 @@ language: ruby
 before_install:
   - gem install bundler -v 1.14.6
   - gem install rubocop
-  - sudo apt-get update -qq
-  - sudo apt-get install -qq twemproxy
+  - sudo add-apt-repository ppa:twemproxy/stable
+  - sudo apt-get update
+  - sudo apt-get install twemproxy=0.4.1-2
 services:
   - redis-server
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -14,7 +14,7 @@ before_install:
   - gem install rubocop
   - sudo add-apt-repository -y ppa:twemproxy/stable
   - sudo apt-get update -y
-  - sudo apt-get install -y twemproxy=0.4.1
+  - sudo apt-get install -y twemproxy
 services:
   - redis-server
 rvm:
@@ -24,6 +24,7 @@ script:
   - bundle exec rubocop --version
   - bundle exec rubocop
   - bundle exec env REDIS_URL=redis://localhost:6379 rake test
+  - nutcracker --version
   - nutcracker --test-conf --conf-file=.travis/nutcracker.yml
   - nutcracker             --conf-file=.travis/nutcracker.yml &
   - bundle exec env REDIS_URL=redis://localhost:22121 rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,4 @@
-sudo: false
+sudo: true
 language: ruby
 before_install:
   - gem install bundler -v 1.14.6

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ before_install:
   - gem install rubocop
   - sudo add-apt-repository -y ppa:twemproxy/stable
   - sudo apt-get update -y
-  - sudo apt-get install -y twemproxy=0.4.1-2
+  - sudo apt-get install -y twemproxy
 services:
   - redis-server
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,12 @@
+#
+# There is no good way to mock Redis's Lua processor, so we test with
+# some infrastructure in place.
+#
+# Also, https://github.com/ProsperWorks/redis-ick/issues/3 revealed issues
+# with running over Twemproxy.
+#
+# We repeat all tests, both connecting directly to Redis and via Twemproxy.
+#
 sudo: true
 language: ruby
 before_install:
@@ -5,7 +14,7 @@ before_install:
   - gem install rubocop
   - sudo add-apt-repository -y ppa:twemproxy/stable
   - sudo apt-get update -y
-  - sudo apt-get install -y twemproxy
+  - sudo apt-get install -y twemproxy=0.4.1
 services:
   - redis-server
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,6 +3,7 @@ language: ruby
 before_install:
   - gem install bundler -v 1.14.6
   - gem install rubocop
+  - apt-get twemproxy
 services:
   - redis-server
 rvm:
@@ -12,3 +13,6 @@ script:
   - bundle exec rubocop --version
   - bundle exec rubocop
   - bundle exec env REDIS_URL=redis://localhost:6379 rake test
+  - nutcracker --test-conf --conf-file=.travis/nutcracker.yml
+  - nutcracker             --conf-file=.travis/nutcracker.yml &
+  - bundle exec env REDIS_URL=redis://localhost:22121 rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,9 @@ language: ruby
 before_install:
   - gem install bundler -v 1.14.6
   - gem install rubocop
-  - sudo add-apt-repository ppa:twemproxy/stable
-  - sudo apt-get update
-  - sudo apt-get install twemproxy=0.4.1-2
+  - sudo add-apt-repository -y ppa:twemproxy/stable
+  - sudo apt-get update -y
+  - sudo apt-get install -y twemproxy=0.4.1-2
 services:
   - redis-server
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,7 +11,6 @@ sudo: true
 language: ruby
 before_install:
   - gem install bundler -v 1.14.6
-  - gem install rubocop
   - sudo add-apt-repository -y ppa:twemproxy/stable
   - sudo apt-get update -y
   - sudo apt-get install -y twemproxy
@@ -20,7 +19,6 @@ services:
 rvm:
   - 2.1.6
 script:
-  - rubocop --version
   - bundle exec rubocop --version
   - bundle exec rubocop
   - bundle exec env REDIS_URL=redis://localhost:6379 rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,12 +18,13 @@ services:
   - redis-server
 rvm:
   - 2.1.6
-script:
+before_script:
   - bundle exec rubocop --version
-  - bundle exec rubocop
-  - bundle exec env REDIS_URL=redis://localhost:6379 rake test
   - nutcracker --version
   - nutcracker --test-conf --conf-file=.travis/nutcracker.yml
   - nutcracker             --conf-file=.travis/nutcracker.yml &
+  - sleep 0.3
+script:
+  - bundle exec rubocop
+  - bundle exec env REDIS_URL=redis://localhost:6379 rake test
   - bundle exec env REDIS_URL=redis://localhost:22121 rake test
-  - pkill nutcracker

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,8 @@ language: ruby
 before_install:
   - gem install bundler -v 1.14.6
   - gem install rubocop
-  - apt-get twemproxy
+  - sudo apt-get update -qq
+  - sudo apt-get install -qq twemproxy
 services:
   - redis-server
 rvm:

--- a/.travis.yml
+++ b/.travis.yml
@@ -26,3 +26,4 @@ script:
   - nutcracker --test-conf --conf-file=.travis/nutcracker.yml
   - nutcracker             --conf-file=.travis/nutcracker.yml &
   - bundle exec env REDIS_URL=redis://localhost:22121 rake test
+  - pkill nutcracker

--- a/.travis/nutcracker.yml
+++ b/.travis/nutcracker.yml
@@ -1,0 +1,6 @@
+test:
+  redis:            true
+  auto_eject_hosts: false
+  listen:           127.0.0.1:22121
+  servers:
+   - 127.0.0.1:6379:1

--- a/lib/redis/ick.rb
+++ b/lib/redis/ick.rb
@@ -476,7 +476,8 @@ class Redis
       local ick_cset_size = redis.call('ZCARD',ick_cset_key)
       local ick_stats     = {
         'key',        ick_key,
-        'keys',       { ick_key, ick_pset_key, ick_cset_key },
+        'pset_key',   ick_pset_key,
+        'cset_key',   ick_cset_key,
         'ver',        ick_ver,
         'cset_size',  ick_cset_size,
         'pset_size',  ick_pset_size,

--- a/lib/redis/ick/version.rb
+++ b/lib/redis/ick/version.rb
@@ -24,11 +24,15 @@ class Redis
     #         prescriptive hash claims.  Identified limits of
     #         prescriptive hash robustness.
     #
+    # 0.0.5 - Rework ickstats so it no longer angers Twemproxy, per
+    #         https://github.com/ProsperWorks/redis-ick/issues/3,
+    #         by producing a nested Array response.
+    #
     # 0.1.0 - (future) Big README.md and Rdoc update, solicit feedback
     #         from select external beta users.
     #
     # 0.2.0 - (future) Incorporate feedback, announce.
     #
-    VERSION = '0.0.4'.freeze
+    VERSION = '0.0.5'.freeze
   end
 end


### PR DESCRIPTION
Exploring https://github.com/ProsperWorks/redis-ick/issues/3 and https://github.com/twitter/twemproxy/issues/537.

Changes the format of the extra `keys` information which was added to ICKSTATS in 0.0.4 (https://github.com/ProsperWorks/redis-ick/pull/2) so that it is compatible with Twemproxy.

Upgrades TravisCI tests so we always test w/ both Redis and Twemproxy=>Redis.

Bumps redis-ick to 0.0.5.
