### PR TITLE
ickexchange

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -50,6 +50,15 @@ Metrics/MethodLength:
 Layout:
   Enabled: false
 
+# As a group, the Style cops are bewilderingly opiniated.
+#
+# In some cases IMO they are harmful e.g. Style/TernaryParentheses.
+#
+# I reject these cops.
+#
+Style:
+  Enabled: false
+
 # I like a lot of the Lint tests, but not these.
 #
 Lint/AmbiguousBlockAssociation:           # obnoxiously rejects idiomatic Ruby
@@ -76,77 +85,3 @@ Lint/AmbiguousBlockAssociation:           # obnoxiously rejects idiomatic Ruby
 Performance/HashEachMethods:
   Enabled: false
 
-# This does no more than insist I type "format" instead of "sprintf",
-# where the two are aliases.
-#
-Style/FormatString:
-  Enabled: false
-
-# There is nothing wrong with Ruby 1.9 Hash syntax.
-#
-Style/HashSyntax:
-  Enabled: false
-
-# No.  Indeed, postfix if can often drive a line over 80 columns wide.
-#
-Style/IfUnlessModifier:
-  Enabled: false
-
-# No.  There is nothing wrong with "if !foo".
-#
-# As far as I'm concerned, "unless" is in poor taste because it means
-# I have to think in English in two different logical senses - and
-# English is a poor language for logical senses.
-#
-Style/NegatedIf:
-  Enabled: false
-
-# "Do not use semicolons to terminate expressions."
-#
-# That's great when I terminate a single-line expression with a
-# redundant semicolo because I forget I'm not using C.
-#
-# But when I'm using a semicolon to separate two expressions there is
-# no other choice.  So this really ought to be Style/OneExprPerLine,
-# which I reject.
-#
-Style/Semicolon:
-  Enabled: false
-
-# No.
-#
-# Some lines must have '\"'.  It is ugly to use a mix of '"' and '\''
-# in LoCs which are close to one another.  Therefore, banning '"' if
-# '"' is not strictly necessary drives visual inconsistency.
-#
-Style/StringLiterals:
-  Enabled: false
-
-# This is the same kind of obnoxious pedantry which drove Hungarian
-# Notation.
-#
-# The [] literal syntax is perfectly servicable and there is no point
-# _tightly_ coupling it to the content of the array.  That's why we
-# have context-free grammers!
-#
-Style/SymbolArray:
-  Enabled: false
-
-# Shockingly, this cop requires us to *OMIT*, not *INCLUDE* parens in
-# ternery conditons.
-#
-# IMO this one is actively harmful in that it discourages attention to
-# clarity and avoiding some nasty precedence surprises.
-#
-Style/TernaryParentheses:
-  Enabled: false
-
-# I am a huge fan of using trailing commas when I break an argument
-# list down one-per line.
-#
-# As such, I reject these tests.
-#
-Style/TrailingCommaInArguments:
-  Enabled: false
-Style/TrailingCommaInLiteral:
-  Enabled: false

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -1,4 +1,3 @@
-
 AllCops:
   Include:
     - Rakefile

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -63,25 +63,3 @@ Style:
 #
 Lint/AmbiguousBlockAssociation:           # obnoxiously rejects idiomatic Ruby
   Enabled: false
-
-# Ick#ickreserve returns an Array of Arrays.
-#
-# Performance/HashEachMethods complains that:
-#
-#   ick.ickreserve('key',num).each do |message,score|
-#     ...
-#   end
-#
-# would be more efficient as a each_key loop.
-#
-# This cop inappropriately requires us to change working code to
-# broken code.  This is a known issue which the authors of Rubocop do
-# not intend to change:
-#
-#   https://github.com/bbatsov/rubocop/issues/4732
-#
-# My reaction is to blacklist this cop.
-#
-Performance/HashEachMethods:
-  Enabled: false
-

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@
 sudo: true
 language: ruby
 before_install:
-  - gem install bundler -v 1.14.6
+  - gem install bundler -v 1.16.1
   - sudo add-apt-repository -y ppa:twemproxy/stable
   - sudo apt-get update -y
   - sudo apt-get install -y twemproxy

--- a/.travis.yml
+++ b/.travis.yml
@@ -28,6 +28,6 @@ before_script:
   - nutcracker             --conf-file=.travis/nutcracker.yml &
   - sleep 0.3
 script:
-  - bundle exec rubocop
+  - bundle exec rubocop --display-cop-names --display-style-guide
   - bundle exec env REDIS_URL=redis://localhost:6379 rake test
   - bundle exec env REDIS_URL=redis://localhost:22121 rake test

--- a/.travis.yml
+++ b/.travis.yml
@@ -18,6 +18,9 @@ services:
   - redis-server
 rvm:
   - 2.1.6
+  - 2.2.9
+  - 2.4.3
+  - 2.5.0
 before_script:
   - bundle exec rubocop --version
   - nutcracker --version

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,30 @@
+## 0.1.0 (2018-03-20)
+
+- Added ickexchange which combines ickcommit+ickreserve.
+- Introduced backwash to ickreserve and ickexchange.
+- Expanded .travis.yml to cover more rvm versions.
+- Shrink Rubocop coverage to exclude `Style/*`.
+
+## 0.0.5 (2017-09-20)
+
+- Rework ickstats so it no longer angers Twemproxy, per https://github.com/ProsperWorks/redis-ick/issues/3, by producing a nested Array response.
+
+## 0.0.4 (2017-09-12)
+
+- Imported text from original design doc to README.md, polish.
+- Rubocop polish and defiance.
+- Development dependency on [redis-key_hash](https://github.com/ProsperWorks/redis-key_hash) to test prescriptive hash claims.
+- Identified limits of prescriptive hash robustness.
+
+## 0.0.3 (2017-08-29)
+- Got .travis.yml working with a live redis-server.
+- Runtime dependency on redis-script_manager for Ick._eval.
+- Initial Rubocop integration.
+- Misc cleanup.
+
+## 0.0.2 (2017-08-29)
+- Broke out into Prosperworks/redis-ick, make public.
+
+## 0.0.1 (prehistory)
+- Still in Prosperworks/ALI/vendor/gems/redis-ick.
+

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 - Introduced backwash to ickreserve and ickexchange.
 - Expanded .travis.yml to cover more rvm versions.
 - Shrink Rubocop coverage to exclude `Style/*`.
+- Moves version history out into CHANGELOG.md.
 
 ## 0.0.5 (2017-09-20)
 

--- a/README.md
+++ b/README.md
@@ -81,8 +81,8 @@ taken after process_batch_slowly().  Only documents whose timestamps
 did not change between the two snapshots are removed from the queue.
 
 Notice how the critical section no longer includes
-process_batch_slowly().  Instead it only spans two Redis ops and some
-local set arithmetic.
+process_batch_slowly().  Instead it only spans two Redis ops and a bit
+of local set arithmetic.
 
 The critical section which causes the Forgotten Dirtiness Problem is
 still there, but is much smaller.  In practice we see
@@ -128,7 +128,7 @@ time skew in the producers.  The longer entries stay in the consumer
 set, the more they implicitly percolate toward the cold end regardless
 of how many updates they receive.  Ditto in the consumer set.
 Provided that all producers make a best effort to use only current or
-future timestamps when they call *ickadd*, the **ickreserve** batch
+future timestamps when they call **ickadd*, the **ickreserve** batch
 will always include the oldest entries and there will be no
 starvation.
 
@@ -147,9 +147,9 @@ To reduce Redis round-trips, Ick also supports an operation
 Apology: I know that [Two-Phase
 Commit](https://en.wikipedia.org/wiki/Two-phase_commit_protocol) has a
 different technical meaning than what Ick does.  Unfortunately I can't
-find a better name for this very common failsafe queue pattern.  I
-suppose we could think of the Redis sorted set as the coordinator and
-the consumer process as the (single) participant node and, generously,
+find a better name for this common fail-safe pattern.  I suppose we
+could think of the Redis sorted set as the coordinator and the
+consumer process as the (single) participant node and, generously,
 Two-Phase Commit might be taken to describe Ick.
 
 
@@ -210,10 +210,10 @@ Even though one Ick uses three Redis keys, Ick is compatible with
 Redis Cluster.  At ProsperWorks we use it with RedisLabs Enterprise
 Cluster.
 
-Ick does some very tricky things to compute the producer set and
-consumer set keys from the master key in a way which puts them all on
-the same slot in both Redis Cluster and with RLEC's default
-prescriptive hashing algorithm.
+Ick does tricky things to compute the producer set and consumer set
+keys from the master key in a way which puts them all on the same slot
+in both Redis Cluster and with RLEC's default prescriptive hashing
+algorithm.
 
 See [redis-key_hash](https://github.com/ProsperWorks/redis-key_hash)
 for how test this.

--- a/lib/redis/ick.rb
+++ b/lib/redis/ick.rb
@@ -227,11 +227,16 @@ class Redis
     #
     # @param max_size max number of messages to reserve
     #
+    # @param backwash if true, in the reserve function cset members
+    # with high scores are swapped out for pset members with lower
+    # scores.  Otherwise cset members remain in the cset until
+    # committed regardless of how low scores in the pset might be.
+    #
     # @return a list of up to max_size pairs, similar to
     # Redis.current.zrange() withscores: [ member_string, score_number ]
     # representing the lowest-scored elements from the producer set.
     #
-    def ickreserve(ick_key,max_size=0)
+    def ickreserve(ick_key,max_size=0,backwash: false)
       if !ick_key.is_a?(String)
         raise ArgumentError, "bogus non-String ick_key #{ick_key}"
       end
@@ -249,7 +254,7 @@ class Redis
           LUA_ICKEXCHANGE,
           ick_key,
           max_size,
-          false,     # TODO: backwash not supported in ickreserve
+          backwash ? 'backwash' : false,
         )
       end
       if raw_results.is_a?(Redis::Future)

--- a/lib/redis/ick.rb
+++ b/lib/redis/ick.rb
@@ -374,6 +374,17 @@ class Redis
     #
     def _postprocess(raw_results,callback)
       if raw_results.is_a?(Redis::Future)
+        #
+        # Redis::Future have a built-in mechanism for calling a
+        # transformation on the raw results.
+        #
+        # Here, we monkey-patch not the Redis::Future class, but just
+        # this one raw_results object.  We give ourselves a door to
+        # set the post-processing transformation.
+        #
+        # The ransformation will be called only once when the real
+        # results are materialized.
+        #
         class << raw_results
           def transformation=(transformation)
             raise "transformation collision" if @transformation
@@ -383,6 +394,9 @@ class Redis
         raw_results.transformation = callback
         raw_results
       else
+        #
+        # If not Redis::Future, we invoke the callback immediately.
+        #
         callback.call(raw_results)
       end
     end

--- a/lib/redis/ick.rb
+++ b/lib/redis/ick.rb
@@ -382,7 +382,7 @@ class Redis
         # this one raw_results object.  We give ourselves a door to
         # set the post-processing transformation.
         #
-        # The ransformation will be called only once when the real
+        # The transformation will be called only once when the real
         # results are materialized.
         #
         class << raw_results

--- a/lib/redis/ick.rb
+++ b/lib/redis/ick.rb
@@ -669,8 +669,10 @@ class Redis
     }).freeze
 
     #######################################################################
-    # LUA_ICKEXCHANGE
+    # LUA_ICKEXCHANGE: commit then reserve
     #######################################################################
+    #
+    # Commit Function
     #
     # Removes specified members in ARGV[2..N] from the pset, then tops
     # up the cset to up to size ARGV[1] by shifting the lowest-scored
@@ -678,7 +680,9 @@ class Redis
     #
     # The cset might already be full, in which case we may shift fewer
     # than ARGV[1] elements.
-
+    #
+    # Reserve Function
+    #
     # Tops up the cset to up to size ARGV[1] by shifting the
     # lowest-scored members over from the pset.
     #
@@ -694,12 +698,13 @@ class Redis
     #
     # @param ARGV[2..N] messages to be removed from the cset before reserving
     #
-    # @return a bulk response, the number of members removed followed
-    # by ARGV[1] pairs [member,score,...]
+    # @return a bulk response, the number of members removed from the
+    # cset by the commit function followed by up to ARGV[1] pairs
+    # [member,score,...] from the reserve funciton.
     #
-    # Note: This this Lua unpacks ARGV with the iterator ipairs()
-    # instead of unpack() to avoid a "too many results to unpack"
-    # failure at 8000 args.  However, the loop over many redis.call is
+    # Note: This Lua unpacks ARGV with the iterator ipairs() instead
+    # of unpack() to avoid a "too many results to unpack" failure at
+    # 8000 args.  However, the loop over many redis.call is
     # regrettably heavy-weight.  From a performance standpoint it
     # would be preferable to call ZREM in larger batches.
     #

--- a/lib/redis/ick.rb
+++ b/lib/redis/ick.rb
@@ -256,14 +256,23 @@ class Redis
         class << raw_ickreserve_results
           alias_method :original_value, :value
           def value
-            original_value.each_slice(2).map do |p|
+            #
+            # original_value[1..-1] to skip the first element,
+            # num_committed, from the bulk response from
+            # LUA_ICKEXCHANGE.
+            #
+            original_value[1..-1].each_slice(2).map do |p|
               [ p[0], ::Redis::Ick._floatify(p[1]) ]
             end
           end
         end
         raw_ickreserve_results
       else
-        results = raw_ickreserve_results.each_slice(2).map do |p|
+        #
+        # raw_ickreserve_results[1..-1] to skip the first element,
+        # num_committed, from the bulk response from LUA_ICKEXCHANGE.
+        #
+        results = raw_ickreserve_results[1..-1].each_slice(2).map do |p|
           [ p[0], ::Redis::Ick._floatify(p[1]) ]
         end
         _statsd_timing('profile.ick.ickreserve.num_results',results.size)
@@ -345,14 +354,23 @@ class Redis
         class << raw_results
           alias_method :original_value, :value
           def value
-            original_value.each_slice(2).map do |p|
+            #
+            # original_value[1..-1] to skip the first element,
+            # num_committed, from the bulk response from
+            # LUA_ICKEXCHANGE.
+            #
+            original_value[1..-1].each_slice(2).map do |p|
               [ p[0], ::Redis::Ick._floatify(p[1]) ]
             end
           end
         end
         raw_results
       else
-        results = raw_results.each_slice(2).map do |p|
+        #
+        # raw_results[1..-1] to skip the first element, num_committed,
+        # from the bulk response from LUA_ICKEXCHANGE.
+        #
+        results = raw_results[1..-1].each_slice(2).map do |p|
           [ p[0], ::Redis::Ick._floatify(p[1]) ]
         end
         _statsd_timing('profile.ick.ickexchange.num_results',results.size)
@@ -686,35 +704,38 @@ class Redis
     # would be preferable to call ZREM in larger batches.
     #
     LUA_ICKEXCHANGE = (LUA_ICK_PREFIX + %{
-      local reserve_size    = tonumber(ARGV[1])
-      local argc            = table.getn(ARGV)
-      local num_committed   = 0
+      local reserve_size   = tonumber(ARGV[1])
+      local argc           = table.getn(ARGV)
+      local num_committed  = 0
       for i = 2,argc,1 do
-        local num_zrem      = redis.call('ZREM',ick_cset_key,ARGV[i])
-        num_committed       = num_committed + num_zrem
+        local num_zrem     = redis.call('ZREM',ick_cset_key,ARGV[i])
+        num_committed      = num_committed + num_zrem
       end
       while true do
-        local cset_size     = redis.call('ZCARD',ick_cset_key)
+        local cset_size    = redis.call('ZCARD',ick_cset_key)
         if cset_size and reserve_size <= cset_size then
           break
         end
-        local first_in_pset = redis.call('ZRANGE',ick_pset_key,0,0,'WITHSCORES')
-        if 0 == table.getn(first_in_pset) then
+        local first_pset   = redis.call('ZRANGE',ick_pset_key,0,0,'WITHSCORES')
+        if 0 == table.getn(first_pset) then
           break
         end
-        local first_member  = first_in_pset[1]
-        local first_score   = tonumber(first_in_pset[2])
+        local first_member = first_pset[1]
+        local first_score  = tonumber(first_pset[2])
         redis.call('ZREM',ick_pset_key,first_member)
-        local old_score     = redis.call('ZSCORE',ick_cset_key,first_member)
+        local old_score    = redis.call('ZSCORE',ick_cset_key,first_member)
         if false == old_score or first_score < tonumber(old_score) then
           redis.call('ZADD',ick_cset_key,first_score,first_member)
         end
       end
       redis.call('SETNX', ick_key, 'ick.v1')
-      local result          = { num_committed }
+      local result         = { num_committed }
       if reserve_size > 0 then
-        local max           = reserve_size - 1
-        result = result + redis.call('ZRANGE',ick_cset_key,0,max,'WITHSCORES')
+        local max          = reserve_size - 1
+        local zrange       = redis.call('ZRANGE',ick_cset_key,0,max,'WITHSCORES')
+        for _i,v in ipairs(zrange) do
+          table.insert(result,v)
+        end
       end
       return result
     }).freeze

--- a/lib/redis/ick/version.rb
+++ b/lib/redis/ick/version.rb
@@ -28,8 +28,10 @@ class Redis
     #         https://github.com/ProsperWorks/redis-ick/issues/3,
     #         by producing a nested Array response.
     #
-    # 0.1.0 - LUA_ICKCOMMIT and LUA_ICKCOMMIT combined to LUA_ICKEXCHANGE.
+    # 0.1.0 - Added ickexchange op which combines ickcommit+ickreserve.
+    #         Introduced backwash to ickreserve and ickexchange.
     #         Expanded .travis.yml to cover more rvm versions.
+    #         Shrink Rubocop coverage to exclude Style/*.
     #
     VERSION = '0.1.0'.freeze
   end

--- a/lib/redis/ick/version.rb
+++ b/lib/redis/ick/version.rb
@@ -1,38 +1,5 @@
 class Redis
   class Ick
-    #
-    # Version plan/history:
-    #
-    # 0.0.1 - Still in Prosperworks/ALI/vendor/gems/redis-ick.
-    #
-    # 0.0.2 - Broke out into Prosperworks/redis-ick, make public.
-    #
-    # 0.0.3 - Got .travis.yml working with a live redis-server.
-    #
-    #         Runtime dependency on redis-script_manager for
-    #         Ick._eval.
-    #
-    #         Initial Rubocop integration.
-    #
-    #         Misc cleanup.
-    #
-    # 0.0.4 - Imported text from original design doc to README.md, polish.
-    #
-    #         Rubocop polish and defiance.
-    #
-    #         Development dependency on redis-key_hash to test
-    #         prescriptive hash claims.  Identified limits of
-    #         prescriptive hash robustness.
-    #
-    # 0.0.5 - Rework ickstats so it no longer angers Twemproxy, per
-    #         https://github.com/ProsperWorks/redis-ick/issues/3,
-    #         by producing a nested Array response.
-    #
-    # 0.1.0 - Added ickexchange op which combines ickcommit+ickreserve.
-    #         Introduced backwash to ickreserve and ickexchange.
-    #         Expanded .travis.yml to cover more rvm versions.
-    #         Shrink Rubocop coverage to exclude Style/*.
-    #
     VERSION = '0.1.0'.freeze
   end
 end

--- a/lib/redis/ick/version.rb
+++ b/lib/redis/ick/version.rb
@@ -28,11 +28,9 @@ class Redis
     #         https://github.com/ProsperWorks/redis-ick/issues/3,
     #         by producing a nested Array response.
     #
-    # 0.1.0 - (future) Big README.md and Rdoc update, solicit feedback
-    #         from select external beta users.
+    # 0.1.0 - LUA_ICKCOMMIT and LUA_ICKCOMMIT combined to LUA_ICKEXCHANGE.
+    #         Expanded .travis.yml to cover more rvm versions.
     #
-    # 0.2.0 - (future) Incorporate feedback, announce.
-    #
-    VERSION = '0.0.5'.freeze
+    VERSION = '0.1.0'.freeze
   end
 end

--- a/redis-ick.gemspec
+++ b/redis-ick.gemspec
@@ -21,14 +21,14 @@ Gem::Specification.new do |spec|
   spec.executables   = spec.files.grep(%r{^exe/}) { |f| File.basename(f) }
   spec.require_paths = ['lib']
 
-  spec.add_development_dependency 'bundler',              '~> 1.14'
-  spec.add_development_dependency 'rake',                 '~> 10.0'
-  spec.add_development_dependency 'minitest',             '~> 5.0'
+  spec.add_development_dependency 'bundler',              '~> 1.16.1'
+  spec.add_development_dependency 'minitest',             '~> 5.11.3'
+  spec.add_development_dependency 'rake',                 '~> 12.3.1'
   spec.add_development_dependency 'redis-key_hash',       '~> 0.0.4'
   spec.add_development_dependency 'redis-namespace',      '~> 1.5'
-  spec.add_development_dependency 'rubocop',              '~> 0.50.0'
+  spec.add_development_dependency 'rubocop',              '~> 0.54.0'
 
-  spec.add_dependency             'redis',                '~> 3.2'
+  spec.add_runtime_dependency     'redis',                '~> 3.2'
   spec.add_runtime_dependency     'redis-script_manager', '~> 0.0.2'
 
 end

--- a/test/redis/ick_test.rb
+++ b/test/redis/ick_test.rb
@@ -73,7 +73,8 @@ class Redis
       ].each do |happy_statsd|
         ick = ::Redis::Ick.new(redis, statsd: happy_statsd)
         assert_equal redis,        ick.redis
-        assert_equal happy_statsd, ick.statsd
+        assert_equal happy_statsd, ick.statsd if happy_statsd
+        assert_nil                 ick.statsd if !happy_statsd
       end
       [
         'nope',

--- a/test/redis/ick_test.rb
+++ b/test/redis/ick_test.rb
@@ -349,6 +349,44 @@ class Redis
       assert_equal ['p','q','c'], get
     end
 
+    def test_ickreserve_with_backwash
+      ick = ::Redis::Ick.new(redis)
+      key = @ick_key
+      #
+      # Without backwash, the cset can hold higher-scored elements
+      # than the pset indefinitely until the cset gets committed out.
+      #
+      ick.ickadd(key,70,'a',80,'b',90,'c')
+      assert_equal ['a','b'], ick.ickreserve(key,2).map(&:first)
+      ick.ickadd(key,7, 'x',8 ,'y',9,'z')
+      assert_equal ['a','b'], ick.ickreserve(key,2).map(&:first)
+      #
+      # This is fine when throughput is expected regardless of score.
+      #
+      # When throughput might block when scores are high, we want
+      # repeated ickreserve to always return the lowest-scored
+      # elements in the combined pset+cset.
+      #
+      # That is, we want to observe low-score items in the pset
+      # displacing high-score items in the cset.
+      #
+      get = ick.ickreserve(key,2,backwash: true).map(&:first)
+      assert_equal ['x','y'], get
+      ick.ickcommit(key,'y')
+      get = ick.ickreserve(key,2,backwash: true).map(&:first)
+      assert_equal ['x','z'], get
+      ick.ickcommit(key,'x')
+      get = ick.ickreserve(key,2,backwash: true).map(&:first)
+      assert_equal ['z','a'], get
+      ick.ickcommit(key,'z','a')
+      get = ick.ickreserve(key,2,backwash: true).map(&:first)
+      assert_equal ['b','c'], get
+      ick.ickadd(key,0,'p',1,'q')
+      ick.ickcommit(key,'b','p')
+      get = ick.ickreserve(key,4,backwash: true).map(&:first)
+      assert_equal ['p','q','c'], get
+    end
+
     def test_ickreserve_0_does_not_pick_up_a_past_ickreserve_n
       #
       # On 2016-07-20 I found a long-standing bug in Ick which had never


### PR DESCRIPTION
PR for redis-ick, bumps gem version to 0.1.0.

Introduces `ickexchange` which combines the functions of `ickcommit` and `ickreserve` into a single Redis round-trip.

Introduces a `backwash` option to `ickreserve` and `ickexchange` which causes a full re-merge of the cset into the pset.  This opens up an option to use Icks for scheduling.  A cset full of high scores which are not flowing will not block a pset full of low scores which are qualified to flow.

Expands range of tested `rvm` versions from just `2.1.6` to include also `2.2.9`, `2.4.3`, and `2.5.0`.  I had also hoped to expand the `redis` gem dependency to include everything through the `4` series but unfortunately `redis` `4.0.1` depends on `ruby` `~> 2.2.0` so I can't maintain `2.1.6` compatibility and also upgrade `redis` and also have test coverage in Travis.

Cuts adherence to `Style/*` rubocop cops.  Keeps `Lint/*`.  Each version bump in rubocop they roll out more and more enabled-by-default invasive Styles, some of which are actively harmful.   Also, which ones are in effect is Ruby-version-sensitive so compliance gets a lot more expensive for a pan-Ruby-version gem.

Moves version history out into a more traditional `CHANGELOG.md`.