### PR TITLE
fix-backwash

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.1.1 (2018-06-18)
+
+- Fix crash bug where backwash compared pset scores with cset scores.
+
 ## 0.1.0 (2018-03-20)
 
 - Added ickexchange which combines ickcommit+ickreserve.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 ## 0.1.1 (2018-06-18)
 
-- Fix crash bug where backwash compared pset scores with cset scores.
+- Fix bug in `backwash`: cset scores not converted to number
+  before comparison with pset scores.
 
 ## 0.1.0 (2018-03-20)
 

--- a/lib/redis/ick.rb
+++ b/lib/redis/ick.rb
@@ -763,7 +763,7 @@ class Redis
           local old_score  = redis.call('ZSCORE',ick_pset_key,member)
           if false == old_score then
             redis.call('ZADD',ick_pset_key,score,member)
-          elseif score < tonumber(old_score) then
+          elseif tonumber(score) < tonumber(old_score) then
             redis.call('ZADD',ick_pset_key,score,member)
           end
         end

--- a/lib/redis/ick/version.rb
+++ b/lib/redis/ick/version.rb
@@ -1,5 +1,5 @@
 class Redis
   class Ick
-    VERSION = '0.1.0'.freeze
+    VERSION = '0.1.1'.freeze
   end
 end

--- a/test/redis/ick_test.rb
+++ b/test/redis/ick_test.rb
@@ -281,6 +281,7 @@ class Redis
     end
 
     def test_ickexchange_does_commit_then_reserve
+      return if !ick || !redis
       #
       # It is important that ickexchange remove elements from the cset
       # but _not_ from the pset.
@@ -317,7 +318,7 @@ class Redis
     end
 
     def test_ickexchange_with_backwash
-      ick = ::Redis::Ick.new(redis)
+      return if !ick || !redis
       key = @ick_key
       #
       # Without backwash, the cset can hold higher-scored elements
@@ -351,7 +352,7 @@ class Redis
     end
 
     def test_ickreserve_with_backwash
-      ick = ::Redis::Ick.new(redis)
+      return if !ick || !redis
       key = @ick_key
       #
       # Without backwash, the cset can hold higher-scored elements
@@ -403,13 +404,15 @@ class Redis
     # pset scores.
     #
     def test_backwash_comparison_type_error
+      return if !ick || !redis
       #
       # Set up an un-interesting pset.
       #
-      ick.ickadd(@ick_key,7,'a',8,'b',9,'c')
+      ick.ickadd(@ick_key,7,'a',8,'b')
       #
-      # Re-adding something which is already in the cset with a
-      # different score is no problem.
+      # Re-adding something which is already in the pset with a
+      # different score is no problem.  The backwash code only comes
+      # into play when comparing between the pset and the cset.
       #
       ick.ickadd(@ick_key,7.9,'b') # lower score
       ick.ickadd(@ick_key,8.1,'b') # higher score

--- a/test/redis/ick_test.rb
+++ b/test/redis/ick_test.rb
@@ -1,3 +1,4 @@
+# coding: utf-8
 require 'test_helper'
 require 'redis'
 require 'redis/key_hash'
@@ -385,6 +386,41 @@ class Redis
       ick.ickcommit(key,'b','p')
       get = ick.ickreserve(key,4,backwash: true).map(&:first)
       assert_equal ['p','q','c'], get
+    end
+
+    def test_more_bugs_with_backwash
+      #
+      #  ERR Error running script (call to f_9b9ce7abd2c85e660f6eb5537f7dc3b047b9749c): @user_script:50: user_script:50: attempt to compare string with number
+      #
+      #  Here’s a snippet of that script:
+      #
+      # 42: if 'backwash' == backwash then
+      # 43:   local cset_all     = redis.call('ZRANGE',ick_cset_key,0,-1,'WITHSCORES')
+      # 44:   local cset_size    = table.getn(cset_all)
+      # 45:   for i = 1,cset_size,2 do
+      # 46:     local member     = cset_all[i]
+      # 47:     local score      = cset_all[i+1]
+      # 48:     local old_score  = redis.call('ZSCORE',ick_pset_key,member)
+      # 49:     if false == old_score then
+      # 50:       redis.call('ZADD',ick_pset_key,score,member)
+      # 51:     elseif score < tonumber(old_score) then
+      # 52:       redis.call('ZADD',ick_pset_key,score,member)
+      # 53:     end
+      # 54:   end
+      #
+      ick.ickadd(@ick_key,7.1,'a',8.2,'b',9.3,'c')
+      assert_equal ['a'], ick.ickreserve(@ick_key,1).map(&:first)
+      assert_equal ['a'], ick.ickreserve(@ick_key,1,backwash: true).map(&:first)
+      ick.ickadd(@ick_key,6.9,'z')
+      assert_equal ['a'], ick.ickreserve(@ick_key,1).map(&:first)
+      assert_equal ['z'], ick.ickreserve(@ick_key,1,backwash: true).map(&:first)
+      #assert_equal ['a'], ick.ickreserve(@ick_key,1).map(&:first) # TODO
+      ick.ickadd(@ick_key,9.4,'z')
+      assert_equal ['z'], ick.ickreserve(@ick_key,1).map(&:first)
+      assert_equal ['z'], ick.ickreserve(@ick_key,1,backwash: true).map(&:first)
+      ick.ickadd(@ick_key,5.8,'z')
+      assert_equal ['z'], ick.ickreserve(@ick_key,1).map(&:first)
+      assert_equal ['z'], ick.ickreserve(@ick_key,1,backwash: true).map(&:first)
     end
 
     def test_ickreserve_0_does_not_pick_up_a_past_ickreserve_n


### PR DESCRIPTION
PR for Ick.

Identifies and fixes a backwash bug.

I plan to also complete https://github.com/ProsperWorks/redis-ick/pull/6 and get both on master before releasing `redis-ick 0.1.1`.