### PR TITLE
REDIS-ICK explicit-KEYS

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -12,6 +12,7 @@ language: ruby
 before_install:
   - gem install bundler -v 1.16.1
   - sudo add-apt-repository -y ppa:twemproxy/stable
+  - sudo apt-get update -y
   - sudo apt-get install -y twemproxy
 services:
   - redis-server

--- a/.travis.yml
+++ b/.travis.yml
@@ -12,7 +12,6 @@ language: ruby
 before_install:
   - gem install bundler -v 1.16.1
   - sudo add-apt-repository -y ppa:twemproxy/stable
-  - sudo apt-get update -y
   - sudo apt-get install -y twemproxy
 services:
   - redis-server

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-## 0.1.2 (2012-02-27)
+## 0.1.2 (2019-02-27)
 
 - Expanded .travis.yml to cover more ruby versions.
 - Change Lua scripts so all Redis keys are passed as explicit args.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
-## 0.1.2 (TBD)
+## 0.1.2 (2012-02-27)
 
 - Expanded .travis.yml to cover more ruby versions.
+- Change Lua scripts so all Redis keys are passed as explicit args.
+  - The pset and cset keys are now computed from the main key in Ruby.
+  - This supports certain forms of Redis cluster syncing.
 
 ## 0.1.1 (2018-06-18)
 

--- a/lib/redis/ick.rb
+++ b/lib/redis/ick.rb
@@ -465,7 +465,14 @@ class Redis
       if !ick_key.is_a?(String)
         raise ArgumentError, "bogus non-String ick_key #{ick_key}"
       end
-      Redis::ScriptManager.eval_gently(redis,lua,[ick_key],args)
+      ick_pset_key = "#{ick_key}/ick/{#{ick_key}}/pset"
+      ick_cset_key = "#{ick_key}/ick/{#{ick_key}}/cset"
+      Redis::ScriptManager.eval_gently(
+        redis,
+        lua,
+        [ick_key,ick_pset_key,ick_cset_key],
+        args
+      )
     end
 
     #######################################################################
@@ -535,8 +542,8 @@ class Redis
     LUA_ICK_PREFIX = %{
       local ick_key        = KEYS[1]
       local ick_ver        = redis.call('GET',ick_key)
-      local ick_pset_key   = ick_key .. '/ick/{' .. ick_key .. '}/pset'
-      local ick_cset_key   = ick_key .. '/ick/{' .. ick_key .. '}/cset'
+      local ick_pset_key   = KEYS[2]
+      local ick_cset_key   = KEYS[3]
       local ick_ver_type   = redis.call('TYPE',ick_key).ok
       local ick_pset_type  = redis.call('TYPE',ick_pset_key).ok
       local ick_cset_type  = redis.call('TYPE',ick_cset_key).ok


### PR DESCRIPTION
PR for `redis-ick`.

- Change Lua scripts so all Redis keys are passed as explicit args.
  - The pset and cset keys are now computed from the main key in Ruby.
  - This supports certain forms of Redis cluster syncing.

After I merge this to master I will `gem push` v0.1.2 so I can depend on it from ALI https://github.com/ProsperWorks/ALI/pull/12147.