### PR TITLE
REDIS-ICK ick-ickunlink

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,6 @@
+## 0.1.4 (2019-11-XX) TODO TBD
+  - ICKUNLINK, as ICKDEL but uses Redis UNLINK for O(1) time.
+
 ## 0.1.3 (2019-06-067)
 - Support for redis >= 4.0.0 added.
 - Breaking changes at redis v4.0.0 addressed.


### PR DESCRIPTION
PR for `redis-ick`.

Introduces a new operation `ICKUNLINK`, just like `ICKDEL` but with [`UNLINK`](https://redis.io/commands/unlink) instead of [`DEL`](https://redis.io/commands/del).

When this and https://github.com/ProsperWorks/redis-ick/pull/13 merge to `master` I will release `redis-ick` 0.1.4.