### PR TITLE
REDIS-ICK update-VERSION

### DIFF
--- a/gemfiles/redis_3.0.gemfile.lock
+++ b/gemfiles/redis_3.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    redis-ick (0.1.3)
+    redis-ick (0.1.4)
       redis (>= 3.0.0, < 5.0.0)
       redis-script_manager (~> 0.0.6)
 

--- a/gemfiles/redis_3.1.gemfile.lock
+++ b/gemfiles/redis_3.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    redis-ick (0.1.3)
+    redis-ick (0.1.4)
       redis (>= 3.0.0, < 5.0.0)
       redis-script_manager (~> 0.0.6)
 

--- a/gemfiles/redis_3.2.gemfile.lock
+++ b/gemfiles/redis_3.2.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    redis-ick (0.1.3)
+    redis-ick (0.1.4)
       redis (>= 3.0.0, < 5.0.0)
       redis-script_manager (~> 0.0.6)
 

--- a/gemfiles/redis_3.3.gemfile.lock
+++ b/gemfiles/redis_3.3.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    redis-ick (0.1.3)
+    redis-ick (0.1.4)
       redis (>= 3.0.0, < 5.0.0)
       redis-script_manager (~> 0.0.6)
 

--- a/gemfiles/redis_4.0.gemfile.lock
+++ b/gemfiles/redis_4.0.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    redis-ick (0.1.3)
+    redis-ick (0.1.4)
       redis (>= 3.0.0, < 5.0.0)
       redis-script_manager (~> 0.0.6)
 

--- a/gemfiles/redis_4.1.gemfile.lock
+++ b/gemfiles/redis_4.1.gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: ..
   specs:
-    redis-ick (0.1.3)
+    redis-ick (0.1.4)
       redis (>= 3.0.0, < 5.0.0)
       redis-script_manager (~> 0.0.6)
 

--- a/lib/redis/ick/version.rb
+++ b/lib/redis/ick/version.rb
@@ -1,5 +1,5 @@
 class Redis
   class Ick
-    VERSION = '0.1.3'.freeze
+    VERSION = '0.1.4'.freeze
   end
 end


### PR DESCRIPTION
Whoops, between https://github.com/ProsperWorks/redis-ick/pull/12 and https://github.com/ProsperWorks/redis-ick/pull/13 I forgot to bump `Redis::Ick::VERSION`.